### PR TITLE
Add minimal PHP CRM skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# crm
+# Mini CRM Example
+
+This project provides a very small CRM-like example for a pharmacy.
+It is built using plain PHP (no framework) with MySQLi prepared statements,
+MySQL database, and vanilla HTML/CSS/JavaScript.
+
+## Features
+
+- Login system with admin and operator roles.
+- Admin dashboard to manage products, categories, and operators.
+- Operator dashboard to view products.
+- Basic CRUD pages for products, categories, and operators.
+
+## Setup
+
+1. Create a MySQL database named `crm` and run the following SQL to create tables:
+
+```sql
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin','operator') NOT NULL
+);
+
+CREATE TABLE categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    category_id INT,
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+-- create default admin user (password: adminpass)
+INSERT INTO users (username, password, role) VALUES ('admin', PASSWORD('adminpass'), 'admin');
+```
+
+2. Update `includes/db.php` with your database credentials.
+3. Upload the project files to your hosting account (e.g., Hostinger) and access `index.php`.
+4. Login with the admin account and start adding data.
+
+This is only a minimal example and does not include advanced security or validation. It can be extended to meet additional requirements.

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Admin Dashboard</h2>
+<ul>
+    <li><a href="/products/">Manage Products</a></li>
+    <li><a href="/operators/">Manage Operators</a></li>
+    <li><a href="/categories/">Manage Categories</a></li>
+</ul>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header { background: #333; color: #fff; padding: 10px; }
+header h1 { margin: 0; }
+nav a { color: #fff; margin-right: 10px; }
+main { padding: 20px; }
+form { max-width: 400px; margin: 0 auto; }
+form input, form select { display: block; width: 100%; margin-bottom: 10px; }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,0 +1,1 @@
+// placeholder for future JS

--- a/categories/create.php
+++ b/categories/create.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+
+$name = '';
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $stmt = $mysqli->prepare('INSERT INTO categories (name) VALUES (?)');
+    $stmt->bind_param('s', $name);
+    if ($stmt->execute()) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Error adding category';
+    }
+}
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Add Category</h2>
+<?php if ($message): ?><p style="color:red;"><?= $message ?></p><?php endif; ?>
+<form method="post">
+    <input type="text" name="name" value="<?= htmlspecialchars($name) ?>" required>
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/categories/edit.php
+++ b/categories/edit.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+
+$id = $_GET['id'] ?? 0;
+$stmt = $mysqli->prepare('SELECT name FROM categories WHERE id = ?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$category = $stmt->get_result()->fetch_assoc();
+if (!$category) {
+    die('Category not found');
+}
+
+$name = $category['name'];
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $stmt = $mysqli->prepare('UPDATE categories SET name=? WHERE id=?');
+    $stmt->bind_param('si', $name, $id);
+    if ($stmt->execute()) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Error updating category';
+    }
+}
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Edit Category</h2>
+<?php if ($message): ?><p style="color:red;"><?= $message ?></p><?php endif; ?>
+<form method="post">
+    <input type="text" name="name" value="<?= htmlspecialchars($name) ?>" required>
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/categories/index.php
+++ b/categories/index.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+include __DIR__ . '/../includes/header.php';
+
+$result = $mysqli->query('SELECT id, name FROM categories');
+?>
+<h2>Categories</h2>
+<a href="create.php">Add Category</a>
+<table border="1" cellpadding="5" cellspacing="0">
+<tr><th>ID</th><th>Name</th><th>Actions</th></tr>
+<?php while ($row = $result->fetch_assoc()): ?>
+<tr>
+    <td><?= htmlspecialchars($row['id']) ?></td>
+    <td><?= htmlspecialchars($row['name']) ?></td>
+    <td><a href="edit.php?id=<?= $row['id'] ?>">Edit</a></td>
+</tr>
+<?php endwhile; ?>
+</table>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+
+require_once __DIR__ . '/db.php';
+
+function login($username, $password) {
+    global $mysqli;
+    $stmt = $mysqli->prepare('SELECT id, password, role FROM users WHERE username = ?');
+    $stmt->bind_param('s', $username);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($row = $result->fetch_assoc()) {
+        if (password_verify($password, $row['password'])) {
+            $_SESSION['user_id'] = $row['id'];
+            $_SESSION['role'] = $row['role'];
+            return true;
+        }
+    }
+    return false;
+}
+
+function require_login() {
+    if (!isset($_SESSION['user_id'])) {
+        header('Location: /login.php');
+        exit();
+    }
+}
+
+function require_role($role) {
+    require_login();
+    if ($_SESSION['role'] !== $role) {
+        header('Location: /');
+        exit();
+    }
+}
+?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,12 @@
+<?php
+$host = 'localhost';
+$user = 'root';
+$pass = '';
+$db = 'crm';
+
+$mysqli = new mysqli($host, $user, $pass, $db);
+if ($mysqli->connect_error) {
+    die('Connect Error (' . $mysqli->connect_errno . ') '
+        . $mysqli->connect_error);
+}
+?>

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer>
+    <p>&copy; <?php echo date('Y'); ?> Mini CRM</p>
+</footer>
+</body>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,0 +1,28 @@
+<?php require_once __DIR__ . '/auth.php'; ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <title>Mini CRM</title>
+</head>
+<body>
+<header>
+    <h1>Mini CRM</h1>
+    <?php if (isset($_SESSION['user_id'])): ?>
+    <nav>
+        <a href="/">Home</a>
+        <?php if ($_SESSION['role'] === 'admin'): ?>
+            <a href="/admin/">Admin Dashboard</a>
+            <a href="/operators/">Operators</a>
+        <?php else: ?>
+            <a href="/operator/">Operator Dashboard</a>
+        <?php endif; ?>
+        <a href="/products/">Products</a>
+        <a href="/categories/">Categories</a>
+        <a href="/logout.php">Logout</a>
+    </nav>
+    <?php endif; ?>
+</header>
+<main>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__ . '/includes/auth.php';
+
+if (isset($_SESSION['user_id'])) {
+    if ($_SESSION['role'] === 'admin') {
+        header('Location: /admin/');
+        exit();
+    } else {
+        header('Location: /operator/');
+        exit();
+    }
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (login($_POST['username'], $_POST['password'])) {
+        header('Location: /');
+        exit();
+    } else {
+        $error = 'Invalid username or password';
+    }
+}
+?>
+<?php include __DIR__ . '/includes/header.php'; ?>
+<h2>Login</h2>
+<?php if ($error): ?><p style="color:red;"><?= $error ?></p><?php endif; ?>
+<form method="post">
+    <input type="text" name="username" placeholder="Username" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <input type="submit" value="Login">
+</form>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/includes/auth.php';
+session_destroy();
+header('Location: /');
+exit();
+?>

--- a/operator/index.php
+++ b/operator/index.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('operator');
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Operator Dashboard</h2>
+<ul>
+    <li><a href="/products/">View Products</a></li>
+</ul>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/operators/create.php
+++ b/operators/create.php
@@ -1,0 +1,28 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+
+$username = '';
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'];
+    $password = password_hash($_POST['password'], PASSWORD_BCRYPT);
+    $stmt = $mysqli->prepare("INSERT INTO users (username, password, role) VALUES (?, ?, 'operator')");
+    $stmt->bind_param('ss', $username, $password);
+    if ($stmt->execute()) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Error adding operator';
+    }
+}
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Add Operator</h2>
+<?php if ($message): ?><p style="color:red;"><?= $message ?></p><?php endif; ?>
+<form method="post">
+    <input type="text" name="username" value="<?= htmlspecialchars($username) ?>" required>
+    <input type="password" name="password" required>
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/operators/edit.php
+++ b/operators/edit.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+
+$id = $_GET['id'] ?? 0;
+$stmt = $mysqli->prepare("SELECT username FROM users WHERE id=? AND role='operator'");
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$operator = $stmt->get_result()->fetch_assoc();
+if (!$operator) {
+    die('Operator not found');
+}
+
+$username = $operator['username'];
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'];
+    if (!empty($_POST['password'])) {
+        $password = password_hash($_POST['password'], PASSWORD_BCRYPT);
+        $stmt = $mysqli->prepare('UPDATE users SET username=?, password=? WHERE id=?');
+        $stmt->bind_param('ssi', $username, $password, $id);
+    } else {
+        $stmt = $mysqli->prepare('UPDATE users SET username=? WHERE id=?');
+        $stmt->bind_param('si', $username, $id);
+    }
+    if ($stmt->execute()) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Error updating operator';
+    }
+}
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Edit Operator</h2>
+<?php if ($message): ?><p style="color:red;"> <?= $message ?> </p><?php endif; ?>
+<form method="post">
+    <input type="text" name="username" value="<?= htmlspecialchars($username) ?>" required>
+    <input type="password" name="password" placeholder="New Password (leave blank to keep current)">
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/operators/index.php
+++ b/operators/index.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+include __DIR__ . '/../includes/header.php';
+
+$result = $mysqli->query("SELECT id, username FROM users WHERE role='operator'");
+?>
+<h2>Operators</h2>
+<a href="create.php">Add Operator</a>
+<table border="1" cellpadding="5" cellspacing="0">
+<tr><th>ID</th><th>Username</th><th>Actions</th></tr>
+<?php while ($row = $result->fetch_assoc()): ?>
+<tr>
+    <td><?= htmlspecialchars($row['id']) ?></td>
+    <td><?= htmlspecialchars($row['username']) ?></td>
+    <td><a href="edit.php?id=<?= $row['id'] ?>">Edit</a></td>
+</tr>
+<?php endwhile; ?>
+</table>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/products/create.php
+++ b/products/create.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+
+$name = $category_id = '';
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $category_id = $_POST['category_id'];
+    $stmt = $mysqli->prepare('INSERT INTO products (name, category_id) VALUES (?, ?)');
+    $stmt->bind_param('si', $name, $category_id);
+    if ($stmt->execute()) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Error adding product';
+    }
+}
+
+$categories = $mysqli->query('SELECT id, name FROM categories');
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Add Product</h2>
+<?php if ($message): ?><p style="color:red;"><?= $message ?></p><?php endif; ?>
+<form method="post">
+    <input type="text" name="name" placeholder="Name" value="<?= htmlspecialchars($name) ?>" required>
+    <select name="category_id" required>
+        <option value="">Select Category</option>
+        <?php while ($c = $categories->fetch_assoc()): ?>
+            <option value="<?= $c['id'] ?>" <?= $c['id'] == $category_id ? 'selected' : '' ?>><?= htmlspecialchars($c['name']) ?></option>
+        <?php endwhile; ?>
+    </select>
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/products/edit.php
+++ b/products/edit.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_role('admin');
+
+$id = $_GET['id'] ?? 0;
+$stmt = $mysqli->prepare('SELECT name, category_id FROM products WHERE id = ?');
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$product = $stmt->get_result()->fetch_assoc();
+if (!$product) {
+    die('Product not found');
+}
+
+$name = $product['name'];
+$category_id = $product['category_id'];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $category_id = $_POST['category_id'];
+    $stmt = $mysqli->prepare('UPDATE products SET name=?, category_id=? WHERE id=?');
+    $stmt->bind_param('sii', $name, $category_id, $id);
+    if ($stmt->execute()) {
+        header('Location: index.php');
+        exit();
+    } else {
+        $message = 'Error updating product';
+    }
+}
+
+$categories = $mysqli->query('SELECT id, name FROM categories');
+include __DIR__ . '/../includes/header.php';
+?>
+<h2>Edit Product</h2>
+<?php if ($message): ?><p style="color:red;"><?= $message ?></p><?php endif; ?>
+<form method="post">
+    <input type="text" name="name" value="<?= htmlspecialchars($name) ?>" required>
+    <select name="category_id" required>
+        <?php while ($c = $categories->fetch_assoc()): ?>
+            <option value="<?= $c['id'] ?>" <?= $c['id'] == $category_id ? 'selected' : '' ?>><?= htmlspecialchars($c['name']) ?></option>
+        <?php endwhile; ?>
+    </select>
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../includes/footer.php'; ?>

--- a/products/index.php
+++ b/products/index.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../includes/auth.php';
+require_login();
+include __DIR__ . '/../includes/header.php';
+
+$result = $mysqli->query('SELECT products.id, products.name, categories.name AS category FROM products LEFT JOIN categories ON products.category_id = categories.id');
+?>
+<h2>Products</h2>
+<a href="create.php">Add Product</a>
+<table border="1" cellpadding="5" cellspacing="0">
+<tr><th>ID</th><th>Name</th><th>Category</th><th>Actions</th></tr>
+<?php while ($row = $result->fetch_assoc()): ?>
+<tr>
+    <td><?= htmlspecialchars($row['id']) ?></td>
+    <td><?= htmlspecialchars($row['name']) ?></td>
+    <td><?= htmlspecialchars($row['category']) ?></td>
+    <td>
+        <a href="edit.php?id=<?= $row['id'] ?>">Edit</a>
+    </td>
+</tr>
+<?php endwhile; ?>
+</table>
+<?php include __DIR__ . '/../includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- create basic authentication and header/footer includes
- add admin/operator dashboards
- add CRUD pages for products, categories, and operators
- provide simple CSS and README instructions

## Testing
- `php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624b58b3a4832eb645d90e94cfe5a6